### PR TITLE
Changes to make it work with the latest gitlab-runner

### DIFF
--- a/startup-scripts/prepare-runner.sh
+++ b/startup-scripts/prepare-runner.sh
@@ -49,8 +49,8 @@ function registerRunner() {
   fi
 
   gitlab-ci-multi-runner register --config /etc/gitlab-runner/config.toml --non-interactive \
-  --url $GITLAB_CI_URI --registration-token $REGISTER_TOKEN --tag-list "$RUNNER_TAGS" \
-  --name $RUNNER_NAME --executor docker+machine
+  --url $GITLAB_CI_URI --registration-token $REGISTER_TOKEN \
+  --name $RUNNER_NAME --executor docker+machine --docker-image alpine
 
   local TOKEN=$(sed -n 's/.*token = "\(.*\)".*/\1/p' /etc/gitlab-runner/config.toml)
   echo "Runner registered with token $TOKEN"


### PR DESCRIPTION
The latest gitlab-runner expects a default docker-image (otherwise it fails).
When adding tags, only builds with those tags will be picked up. Without adding tags, all builds will be picked up (which I think is a better default for this lib).
